### PR TITLE
Another approach for dealing with cookie collection handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ Low level API for handling cookies server side.
     cookie = Cookie(name='foo', value='bar', domain='www.example.org')
     str(cookie)
     > "foo=bar; Domain=www.example.org; Path=/"
+    # Cookie name is immutable
+    cookie.name = 'new_name'  # Will raise an attribute error
+
+    # Cookies collection
+    from biscuits import Cookies, Cookie
+    cookies = Cookies()
+    cookies.add(Cookie('name', 'value', domain='example.org'))
+    # or shortcut:
+    cookies.set('name', 'value', domain='example.org')
+    # Get a cookie from the collection
+    cookies['name']
+    # Delete a cookie from the collection
+    del cookies['name']
+    # Loop over cookies
+    for cookie in cookies:
+        headers.add('Set-Cookie', str(cookie))
 
 
 ## Building from source

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -62,3 +62,9 @@ def test_with_all_attributes():
 def test_value_encoding(value, expected):
     cookie = Cookie('key', value)
     assert str(cookie) == expected
+
+
+def test_cannot_change_name():
+    cookie = Cookie('key', 'value', httponly=True)
+    with pytest.raises(AttributeError):
+        cookie.name = 'immutable'

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,38 @@
+from biscuits import Cookies, Cookie
+
+
+def test_add_cookie():
+    cookies = Cookies()
+    cookie = Cookie('foo', 'bar')
+    cookies.add(cookie)
+    assert cookie in cookies
+    assert 'foo' in cookies
+    assert cookies['foo'] == cookie
+
+
+def test_cannot_add_cookies_with_same_name():
+    cookies = Cookies()
+    one = Cookie('foo', 'one')
+    cookies.add(one)
+    assert one in cookies
+    two = Cookie('foo', 'two')
+    cookies.add(two)
+    assert len(cookies) == 1
+    assert cookies['foo'].value == 'one'
+
+
+def test_can_create_cookie_using_set():
+    cookies = Cookies()
+    cookies.set('name', 'value', domain='www.example.org')
+    assert len(cookies) == 1
+    assert cookies['name'].name == 'name'
+    assert cookies['name'].value == 'value'
+    assert cookies['name'].domain == 'www.example.org'
+
+
+def test_del_cookie():
+    cookies = Cookies()
+    cookie = Cookie('foo', 'bar')
+    cookies.add(cookie)
+    del cookies['foo']
+    assert not cookies


### PR DESCRIPTION
While working on implementing a `Cookies` class in Roll, I found that:

- using a `dict` like class, we have a denormalization issue, i.e. a cookie name and it's key can be different, eg.:

```python
cookies.set('foo',' bar')
cookies['foo'].name = 'baz'
```

- using a `list` like class, we can have multiple cookies with the same name (which is invalid), eg:

```python
cookies.set('foo', 'bar')
cookies.set('foo', 'baz')
len(cookies)  # 2
```

So I started implementing the `set` option in Roll, but this needs to implement `__hash__` and `__eq__` on the `Cookie` class (which I was first doing by subclassing it). So I finally thought it may better be in biscuits. To be discussed :)