### PR TITLE
Unescape octal ascii

### DIFF
--- a/biscuits.pyx
+++ b/biscuits.pyx
@@ -18,7 +18,7 @@ cpdef str unquote(str input):
     cdef:
         list output = []
         unsigned int i = 0
-        str hex, current
+        str hex, current, next
         unsigned int length = len(input)
     while i < length:
         current = input[i]
@@ -32,9 +32,20 @@ cpdef str unquote(str input):
             except ValueError:
                 return None
             i += 2
-        elif current == '\\' and i+1 < length and input[i+1] in ('"', '\\'):
-            output.append(input[i+1])
-            i += 1
+        elif current == '\\':
+            if i+1 < length:
+                next = input[i+1]
+                if next in ('"', '\\'):
+                    current = next
+                    i += 1
+                elif next in ('0', '1', '2', '3'):  # Octal escaped char.
+                    next = input[i+1:i+4]
+                    i += 3
+                    try:
+                        current = chr(int(next, 8))
+                    except ValueError:
+                        return None
+            output.append(current)
         else:
             output.append(current)
         i += 1

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -57,6 +57,10 @@ def test_with_all_attributes():
     ('val ue', 'key="val ue"; Path=/'),
     ('val=ue', 'key="val=ue"; Path=/'),
     ('val+ue', 'key=val+ue; Path=/'),
+    ('val,ue', 'key="val\\054ue"; Path=/'),  # Comma is escaped as octal.
+    ('val;ue', 'key="val\\073ue"; Path=/'),  # Same for semi-colon.
+    ('«value»', 'key="\\253value\\273"; Path=/'),  # Same here.
+    ('value©', 'key="value\\251"; Path=/'),  # Same.
     ('val\\ue', 'key="val\\\\ue"; Path=/'),
     ('\\u00e9', 'key="\\\\u00e9"; Path=/'),  # Starts with \
     ('val\\', 'key="val\\\\"; Path=/'),  # Ends with \


### PR DESCRIPTION
We use http.cookies._quote for escaping cookies values, which
also escapes "non text" ASCII chars:

https://github.com/python/cpython/blob/master/Lib/http/cookies.py#L148

Let's be consistent and unescape those chars when parsing.